### PR TITLE
Use cache for installing wasm-pack on GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,12 +15,19 @@ runs:
       run: go install github.com/sqls-server/sqls@latest
       shell: bash
 
+    # for Rust incremental build
+    - name: git-restore-mtime
+      uses: chetan/git-restore-mtime-action@v1.0
+
     - name: Rust cache
       uses: actions/cache@v4
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db
+          sql-extraction/rs/target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # - name: Setup docker (missing on MacOS)

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -13,9 +13,13 @@ runs:
       run: go install github.com/sqls-server/sqls@latest
       shell: bash
 
-    - uses: Swatinem/rust-cache@v2
+    - name: Rust cache
+      uses: actions/cache@v2
       with:
-        workspaces: "sql-extraction/rs -> sql-extraction/rs/target"
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # - name: Setup docker (missing on MacOS)
       #   if: runner.os == 'macos'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -9,12 +9,14 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: "1.22.2"
+        cache: true
+
     - name: Install sqls
       run: go install github.com/sqls-server/sqls@latest
       shell: bash
 
     - name: Rust cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,9 +15,7 @@ runs:
       run: go install github.com/sqls-server/sqls@latest
       shell: bash
 
-    # for Rust incremental build
-    - name: git-restore-mtime
-      uses: chetan/git-restore-mtime-action@v1.0
+    - uses: chetan/git-restore-mtime-action@v2 # for Rust incremental build
 
     - name: Rust cache
       uses: actions/cache@v4

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-$WASM_PACK_VERSION
+          key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION}}
 
       - name: Build
         run: pnpm build:pkg && pnpm i

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,15 +17,17 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Install wasm-pack
-        run: |
-          cargo install --version $WASM_PACK_VERSION wasm-pack
-
       - name: wasm-pack cache
         uses: actions/cache@v4
+        id: wasm-pack-cache
         with:
           path: ~/.cargo/bin/wasm-pack
           key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION}}
+
+      - name: Install wasm-pack
+        if: steps.wasm-pack-cache.outputs.cache-hit == 'false'
+        run: |
+          cargo install --version $WASM_PACK_VERSION wasm-pack
 
       - name: Build
         run: pnpm build:pkg && pnpm i

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Tests
 
 on: pull_request
 
+env:
+  WASM_PACK_VERSION: 0.12.1
+
 jobs:
   test:
     strategy:
@@ -14,9 +17,15 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Install wasm-pack
+        run: |
+          cargo install --version $WASM_PACK_VERSION wasm-pack
+
+      - name: wasm-pack cache
+        uses: actions/cache@v4
         with:
-          version: "v0.12.1"
+          path: ~/.cargo/bin/wasm-pack
+          key: wasm-pack-${{ runner.os }}-$WASM_PACK_VERSION
 
       - name: Build
         run: pnpm build:pkg && pnpm i

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -14,8 +14,9 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: "v0.12.1"
 
       - name: Build
         run: pnpm build:pkg && pnpm i


### PR DESCRIPTION
close #27 
This pull request fixes issue #27 by updating the GitHub Actions workflow to use the `jetli/wasm-pack-action` action instead of manually installing wasm-pack. This action allows for caching of the wasm-pack installation, improving build times.