### PR TITLE
Refactor SQL extraction functions in TypeScript and Rust

### DIFF
--- a/sql-extraction/rs/src/index.ts
+++ b/sql-extraction/rs/src/index.ts
@@ -1,4 +1,19 @@
-export async function extractSqlListRs(sourceTxt: string): Promise<string[]> {
+// TODO: DI
+type SqlNode = {
+  code_range: {
+    start: {
+      line: number; // 0-based
+      character: number; // 0-based
+    };
+    end: {
+      line: number; // 0-based
+      character: number; // 0-based
+    };
+  };
+  content: string;
+};
+
+export async function extractSqlListRs(sourceTxt: string): Promise<SqlNode[]> {
   const { extract_sql_list } = await import("../pkg");
-  return extract_sql_list(sourceTxt);
+  return extract_sql_list(sourceTxt).map((sqlNode) => JSON.parse(sqlNode));
 }

--- a/sql-extraction/ts/src/index.ts
+++ b/sql-extraction/ts/src/index.ts
@@ -1,18 +1,27 @@
 import * as ts from "typescript";
 
-type Range = [from: number, to: number];
-export type SqlNodes = {
-  codeRange: Range;
+// TODO: DI
+export type SqlNode = {
+  code_range: {
+    start: {
+      line: number; // 0-based
+      character: number; // 0-based
+    };
+    end: {
+      line: number; // 0-based
+      character: number; // 0-based
+    };
+  };
   content: string;
 };
 
-export function extractSqlListTs(sourceTxt: string): SqlNodes[] {
+export function extractSqlListTs(sourceTxt: string): SqlNode[] {
   const sourceFile = ts.createSourceFile(
     "unusedFileName",
     sourceTxt,
     ts.ScriptTarget.Latest, // TODO: re-consider this it should be the same as the vscode lsp
   );
-  const sqlNodes: SqlNodes[] = [];
+  const sqlNodes: SqlNode[] = [];
   ts.forEachChild<void>(sourceFile, visit);
   return sqlNodes;
 
@@ -27,8 +36,21 @@ export function extractSqlListTs(sourceTxt: string): SqlNodes[] {
       node.tag.name.text === "$queryRaw" &&
       ts.isNoSubstitutionTemplateLiteral(node.template)
     ) {
+      const { line: startLine, character: startCharacter } =
+        sourceFile.getLineAndCharacterOfPosition(node.template.pos + 1); // +1 is to remove the first back quote
+      const { line: endLine, character: endCharacter } =
+        sourceFile.getLineAndCharacterOfPosition(node.template.end - 1); // -1 is to remove the last back quote
       sqlNodes.push({
-        codeRange: [node.template.pos + 1, node.template.end], // +1 is to remove the first back quote
+        code_range: {
+          start: {
+            line: startLine,
+            character: startCharacter,
+          },
+          end: {
+            line: endLine,
+            character: endCharacter,
+          },
+        },
         content: node.template.rawText ?? "",
       });
     }


### PR DESCRIPTION
This pull request refactors the SQL extraction functions in TypeScript and Rust. It introduces a new type `SqlNode` and updates the functions `extractSqlListRs` and `extractSqlListTs` to return an array of `SqlNode` objects instead of strings. This change improves the readability and maintainability of the code.