### PR TITLE
Update sqls version to v0.2.28 and add Go module cache

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,6 +1,12 @@
 name: Setup
 description: Setup
 
+inputs:
+  sqls-version:
+    description: "sqls version"
+    required: false
+    default: "v0.2.28"
+
 runs:
   using: "composite"
   steps:
@@ -16,7 +22,7 @@ runs:
       with:
         path: |
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go
+        key: ${{ runner.os }}-go-${{ inputs.sqls-version }}
         restore-keys: |
           ${{ runner.os }}-go
 

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -21,6 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
+          ~/.cache/go-build
           ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ inputs.sqls-version }}
         restore-keys: |

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,10 +11,6 @@ runs:
         go-version: "1.22.2"
         cache: true
 
-    - name: Install sqls
-      run: go install github.com/sqls-server/sqls@v0.2.28
-      shell: bash
-
     - name: Go module cache
       uses: actions/cache@v4
       with:
@@ -23,6 +19,10 @@ runs:
         key: ${{ runner.os }}-go
         restore-keys: |
           ${{ runner.os }}-go
+
+    - name: Install sqls
+      run: go install github.com/sqls-server/sqls@v0.2.28
+      shell: bash
 
     - uses: chetan/git-restore-mtime-action@v2 # for Rust incremental build
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,17 +17,11 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: wasm-pack cache
-        uses: actions/cache@v4
-        id: wasm-pack-cache
-        with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION}}
-
-      - name: Install wasm-pack
-        if: steps.wasm-pack-cache.outputs.cache-hit != 'true'
+      - name: Install wasm-pack if not installed
         run: |
-          cargo install --version $WASM_PACK_VERSION wasm-pack
+          if [ ! -f $HOME/.cargo/bin/wasm-pack ]; then
+            cargo install --version $WASM_PACK_VERSION wasm-pack
+          fi
 
       - name: Build
         run: pnpm build:pkg


### PR DESCRIPTION
This pull request updates the sqls version to v0.2.28 and adds Go module cache for improved performance and dependency management.