### PR TITLE
Add SQL formatter in TypeScript and Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-/**/out
-!/vsce/out/test/suite-rs/__snapshots__
+/**/out/*
+!/vsce/out/test
+
+/vsce/out/test/*
+!/vsce/out/test/*/
+
+/vsce/out/test/*/*
+!/vsce/out/test/*/__snapshots__
 
 node_modules
 client/server

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-out
+/**/out
+!/vsce/out/test/suite-rs/__snapshots__
+
 node_modules
 client/server
 .vscode-test

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -11,3 +11,5 @@ export type SqlNode = {
   };
   content: string;
 };
+
+export const ORIGINAL_SCHEME = "sqlsurge";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       jest-environment-node:
         specifier: ^29.7.0
         version: 29.7.0
+      sql-formatter:
+        specifier: ^15.3.1
+        version: 15.3.1
       ts-jest:
         specifier: ^29.1.2
         version: 29.1.2(@babel/core@7.24.3)(@jest/types@29.6.3)(jest@29.7.0)(typescript@5.4.3)
@@ -2144,6 +2147,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
+  /discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+    dev: true
+
   /dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
@@ -2475,6 +2482,11 @@ packages:
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+    dev: true
+
+  /get-stdin@8.0.0:
+    resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
+    engines: {node: '>=10'}
     dev: true
 
   /get-stdin@9.0.0:
@@ -3540,6 +3552,10 @@ packages:
     dev: true
     optional: true
 
+  /moo@0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
+    dev: true
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -3556,6 +3572,16 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.2
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
     dev: true
 
   /neo-async@2.6.2:
@@ -3808,6 +3834,18 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+    dev: true
+
+  /randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
+    dev: true
+
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
@@ -3906,6 +3944,11 @@ packages:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
     dev: true
 
   /reusify@1.0.4:
@@ -4064,6 +4107,15 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
+  /sql-formatter@15.3.1:
+    resolution: {integrity: sha512-L/dqan+Hrt0PpPdCbHcI9bdfOvqaQZR7v5c5SWMJ3bUGQSezK09Mm9q2I3B4iObjaq7FyoldIM+fDSmfzGRXCA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      get-stdin: 8.0.0
+      nearley: 2.20.1
     dev: true
 
   /stack-utils@2.0.6:

--- a/vsce/README.md
+++ b/vsce/README.md
@@ -13,6 +13,10 @@ SQLx Example in Rust:
 - Auto-Completion for SQL Syntax
 - Auto-Completion for Tables and Table Columns (requires sqls configuration)
 - Formatting
+
+  - command: `sqlsurge: Format SQL (command id: sqlsurge.formatSql)
+  - Format on save by default. You can also change config to off by adding `sqlsurge.formatOnSave: false` in settings.json.
+
 - Supporting raw SQL query
   - [Prisma](https://www.prisma.io/docs/orm/prisma-client/queries/raw-database-access/raw-queries) in TypeScript
   - [SQLx](https://github.com/launchbadge/sqlx) in Rust

--- a/vsce/README.md
+++ b/vsce/README.md
@@ -12,6 +12,7 @@ SQLx Example in Rust:
 
 - Auto-Completion for SQL Syntax
 - Auto-Completion for Tables and Table Columns (requires sqls configuration)
+- Formatting
 - Supporting raw SQL query
   - [Prisma](https://www.prisma.io/docs/orm/prisma-client/queries/raw-database-access/raw-queries) in TypeScript
   - [SQLx](https://github.com/launchbadge/sqlx) in Rust
@@ -37,8 +38,8 @@ To use completion for tables and columns, you need to configure the database con
 
 - [x] Support for Prisma in TypeScript
 - [x] Support for SQLx in Rust
-- [x] Install sqls with the command if not found
-- [ ] Format SQL
+- [x] Install guide for sqls
+- [x] Format SQL (Vanilla SQL: sqls, Raw SQL: [SQL Formatter](https://github.com/sql-formatter-org/sql-formatter))
 - [ ] Show quick info symbol
 - [ ] Support to custom raw SQL queries, not just Prisma and SQLx
 - [ ] Execute SQL query

--- a/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Formatting Test Should be formatted with command 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "INSERT INTO
+  todos (description)
+VALUES
+  ($1) RETURNING id",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+  done = TRUE
+WHERE
+  id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+  id,
+  description,
+  done
+FROM
+  todos
+ORDER BY
+  id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;

--- a/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
@@ -1,6 +1,226 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Formatting Test Should be NOT formatted with save if config is disabled 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "INSERT INTO todos ( description ) VALUES ( $1 ) RETURNING id",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET done = TRUE
+WHERE id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT id, description, done
+FROM todos
+ORDER BY id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
 exports[`Formatting Test Should be formatted with command 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "INSERT INTO
+  todos (description)
+VALUES
+  ($1) RETURNING id",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+  done = TRUE
+WHERE
+  id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+  id,
+  description,
+  done
+FROM
+  todos
+ORDER BY
+  id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
+exports[`Formatting Test Should be formatted with save if config is default(enabled) 1`] = `
 "use sqlx::postgres::PgPool;
 use std::env;
 use structopt::StructOpt;

--- a/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
@@ -1,6 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Formatting Test Should be NOT formatted with save if config is disabled 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`SELECT * FROM todos WHERE id = 1;\`;
+  await prisma.$queryRaw\`
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
 exports[`Formatting Test Should be formatted with command 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`SELECT
+  *
+FROM
+  todos
+WHERE
+  id = 1;\`;
+  await prisma.$queryRaw\`
+    INSERT INTO
+  todos (id, description, done)
+VALUES
+  (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
+exports[`Formatting Test Should be formatted with save if config is default(enabled) 1`] = `
 "import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();

--- a/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Formatting Test Should be formatted with command 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`SELECT
+  *
+FROM
+  todos
+WHERE
+  id = 1;\`;
+  await prisma.$queryRaw\`
+    INSERT INTO
+  todos (id, description, done)
+VALUES
+  (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -54,6 +54,10 @@
       {
         "command": "sqlsurge.installSqls",
         "title": "sqlsurge: Install sqls"
+      },
+      {
+        "command": "sqlsurge.formatSql",
+        "title": "sqlsurge: Format SQL"
       }
     ],
     "grammars": [
@@ -87,6 +91,7 @@
     "colorette": "^2.0.20",
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
+    "sql-formatter": "^15.3.1",
     "ts-jest": "^29.1.2",
     "ts-loader": "^9.5.1",
     "vscode-languageclient": "^9.0.1",

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "vscode:prepublish": "pnpm compile --mode production --devtool hidden-source-map",
     "clean": "node -e 'fs.rmSync(`out`, {recursive:true, force:true})'",
-    "compile": "pnpm clean && webpack",
-    "watch": "pnpm clean && webpack --watch",
+    "compile": "webpack",
+    "watch": "webpack --watch",
     "test": "pnpm compile && tsc -p tsconfig.test.json && node ./out/test/runTest.js",
     "test:bg": "xvfb-run pnpm test",
     "watch-tests": "tsc -p . -w",

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -41,12 +41,17 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "sqls",
+      "title": "sqlsurge",
       "properties": {
-        "go.languageServerFlags": {
+        "sqlsurge.sqlLanguageServerFlags": {
           "type": "array",
           "default": [],
           "description": "Flags like -trace and -log to be used while running the language server."
+        },
+        "sqlsurge.formatOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Format SQL on save."
         }
       }
     },

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -17,60 +17,67 @@ export async function commandFormatSqlProvider(
       }
       const document = editor.document;
       const sqlNodes = await refresh(document);
-      // TODO: typescript case
-
       const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
-      if (document.languageId === "rust") {
-        const edit = new vscode.WorkspaceEdit();
-        sqlNodes.map((sqlNode) => {
-          // convert place holder to dummy if there are any place holders such as "$1" or "?"
-          const placeHolderRegExp = /(\$\d+|\?)/g;
-          const placeHolders = sqlNode.content.match(placeHolderRegExp);
-          if (placeHolders) {
-            sqlNode.content = sqlNode.content.replaceAll(
-              placeHolderRegExp,
-              dummyPlaceHolder,
-            );
-          }
 
-          // get formatted content
-          const formattedContentWithDummy = format(sqlNode.content);
+      const edit = new vscode.WorkspaceEdit();
+      sqlNodes.map((sqlNode) => {
+        // get prefix and suffix of space or new line
+        const prefixMatch = sqlNode.content.match(/^(\s*)/);
+        const prefix = prefixMatch ? prefixMatch[0] : "";
+        const suffixMatch = sqlNode.content.match(/(\s*)$/);
+        const suffix = suffixMatch ? suffixMatch[0] : "";
 
-          // reverse the place holders
-          let formattedContent = formattedContentWithDummy;
-          if (placeHolders) {
-            placeHolders.forEach((placeHolder, index) => {
-              formattedContent = formattedContent.replace(
-                dummyPlaceHolder,
-                placeHolder,
-              );
-            });
-          }
+        // convert place holder to dummy if there are any place holders
+        const placeHolderRegExp =
+          document.languageId === "typescript"
+            ? /\$\{.*\}/g
+            : document.languageId === "rust"
+              ? /(\$\d+|\?)/g
+              : undefined;
+        if (placeHolderRegExp === undefined) {
+          throw new Error("placeHolderRegExp is undefined");
+        }
 
-          // get prefix and suffix of space or new line
-          const prefixMatch = sqlNode.content.match(/^(\s*)/);
-          const prefix = prefixMatch ? prefixMatch[0] : "";
-          const suffixMatch = sqlNode.content.match(/(\s*)$/);
-          const suffix = suffixMatch ? suffixMatch[0] : "";
-
-          // replace with formatted content
-          edit.replace(
-            document.uri,
-            new vscode.Range(
-              new vscode.Position(
-                sqlNode.code_range.start.line,
-                sqlNode.code_range.start.character,
-              ),
-              new vscode.Position(
-                sqlNode.code_range.end.line,
-                sqlNode.code_range.end.character,
-              ),
-            ),
-            prefix + formattedContent + suffix,
+        const placeHolders = sqlNode.content.match(placeHolderRegExp);
+        if (placeHolders) {
+          sqlNode.content = sqlNode.content.replaceAll(
+            placeHolderRegExp,
+            dummyPlaceHolder,
           );
-        });
-        vscode.workspace.applyEdit(edit);
-      }
+        }
+
+        // get formatted content
+        const formattedContentWithDummy = format(sqlNode.content);
+
+        // reverse the place holders
+        let formattedContent = formattedContentWithDummy;
+        if (placeHolders) {
+          placeHolders.forEach((placeHolder, index) => {
+            formattedContent = formattedContent.replace(
+              dummyPlaceHolder,
+              placeHolder,
+            );
+          });
+        }
+
+        // replace with formatted content
+        edit.replace(
+          document.uri,
+          new vscode.Range(
+            new vscode.Position(
+              sqlNode.code_range.start.line,
+              sqlNode.code_range.start.character,
+            ),
+            new vscode.Position(
+              sqlNode.code_range.end.line,
+              sqlNode.code_range.end.character,
+            ),
+          ),
+          prefix + formattedContent + suffix,
+        );
+      });
+
+      vscode.workspace.applyEdit(edit);
       console.timeEnd("format"); // TODO: to output channel
     } catch (error) {
       console.error(error); // TODO: to output channel

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -1,0 +1,95 @@
+import type { SqlNode } from "@senken/config";
+
+import { format } from "sql-formatter";
+import * as vscode from "vscode";
+
+export async function commandFormatSqlProvider(
+  refresh: (
+    document: vscode.TextDocument,
+  ) => Promise<(SqlNode & { vFileName: string })[]>,
+) {
+  return vscode.commands.registerCommand("sqlsurge.formatSql", async () => {
+    try {
+      console.time("format"); // TODO: to output channel
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        return;
+      }
+      const document = editor.document;
+      const sqlNodes = await refresh(document);
+      // TODO: typescript case
+
+      const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
+      if (document.languageId === "rust") {
+        const edit = new vscode.WorkspaceEdit();
+        sqlNodes.map((sqlNode) => {
+          // skip if single line query, only support r#"..."# type
+          const fullContent = document.getText();
+          const offset = document.offsetAt(
+            new vscode.Position(
+              sqlNode.code_range.start.line,
+              sqlNode.code_range.start.character,
+            ),
+          );
+          const quote = fullContent.slice(offset - 3, offset);
+          if (quote !== 'r#"') {
+            return;
+          }
+
+          // convert place holder to dummy 00... number if there are any place holders
+          const placeHolderRegExp = /(\$\d+)/g;
+          const placeHolders = sqlNode.content.match(placeHolderRegExp);
+          if (placeHolders) {
+            sqlNode.content = sqlNode.content.replaceAll(
+              placeHolderRegExp,
+              dummyPlaceHolder,
+            );
+          }
+
+          // get formatted content
+          const formattedContentWithDummy = format(sqlNode.content);
+
+          // reverse the place holders
+          let formattedContent = formattedContentWithDummy;
+          if (placeHolders) {
+            placeHolders.forEach((placeHolder, index) => {
+              formattedContent = formattedContent.replace(
+                dummyPlaceHolder,
+                placeHolder,
+              );
+            });
+          }
+
+          // get prefix and suffix of space or new line
+          const prefixMatch = sqlNode.content.match(/^(\s*)/);
+          const prefix = prefixMatch ? prefixMatch[0] : "";
+          const suffixMatch = sqlNode.content.match(/(\s*)$/);
+          const suffix = suffixMatch ? suffixMatch[0] : "";
+
+          // replace with formatted content
+          edit.replace(
+            document.uri,
+            new vscode.Range(
+              new vscode.Position(
+                sqlNode.code_range.start.line,
+                sqlNode.code_range.start.character,
+              ),
+              new vscode.Position(
+                sqlNode.code_range.end.line,
+                sqlNode.code_range.end.character,
+              ),
+            ),
+            prefix + formattedContent + suffix,
+          );
+        });
+        vscode.workspace.applyEdit(edit);
+      }
+      console.timeEnd("format"); // TODO: to output channel
+    } catch (error) {
+      console.error(error); // TODO: to output channel
+      vscode.window.showErrorMessage(
+        `Error on format: ${(error as any).message}`,
+      );
+    }
+  });
+}

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -36,8 +36,8 @@ export async function commandFormatSqlProvider(
             return;
           }
 
-          // convert place holder to dummy 00... number if there are any place holders
-          const placeHolderRegExp = /(\$\d+)/g;
+          // convert place holder to dummy if there are any place holders such as "$1" or "?"
+          const placeHolderRegExp = /(\$\d+|\?)/g;
           const placeHolders = sqlNode.content.match(placeHolderRegExp);
           if (placeHolders) {
             sqlNode.content = sqlNode.content.replaceAll(

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -23,19 +23,6 @@ export async function commandFormatSqlProvider(
       if (document.languageId === "rust") {
         const edit = new vscode.WorkspaceEdit();
         sqlNodes.map((sqlNode) => {
-          // skip if single line query, only support r#"..."# type
-          const fullContent = document.getText();
-          const offset = document.offsetAt(
-            new vscode.Position(
-              sqlNode.code_range.start.line,
-              sqlNode.code_range.start.character,
-            ),
-          );
-          const quote = fullContent.slice(offset - 3, offset);
-          if (quote !== 'r#"') {
-            return;
-          }
-
           // convert place holder to dummy if there are any place holders such as "$1" or "?"
           const placeHolderRegExp = /(\$\d+|\?)/g;
           const placeHolders = sqlNode.content.match(placeHolderRegExp);

--- a/vsce/src/commands/installSqls.ts
+++ b/vsce/src/commands/installSqls.ts
@@ -1,0 +1,57 @@
+import * as vscode from "vscode";
+import { findSqlsInPath } from "../startSqlsClient";
+
+export const command = vscode.commands.registerCommand(
+  "sqlsurge.installSqls",
+  async () => {
+    // check if sqls is already installed
+    let sqlsPath = await findSqlsInPath();
+    if (sqlsPath) {
+      await vscode.window.showInformationMessage("sqls is already installed.");
+      return;
+    }
+
+    // install sqls
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Installing sqls...",
+      },
+      async () => {
+        vscode.window
+          .createOutputChannel("sqlsurge")
+          .appendLine("Installing sqls...");
+
+        // install sqls with command and wait for it
+        const terminal = vscode.window.createTerminal("install sqls");
+        terminal.show();
+        terminal.sendText("go install github.com/sqls-server/sqls@latest");
+        const timeout = 60 * 1000;
+        const start = Date.now();
+        while (Date.now() - start < timeout) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          sqlsPath = await findSqlsInPath();
+          if (sqlsPath) {
+            break;
+          }
+        }
+      },
+    );
+    if (!sqlsPath) {
+      vscode.window.showErrorMessage("Failed to install sqls");
+      return;
+    }
+
+    // after installation
+    vscode.window
+      .createOutputChannel("sqlsurge")
+      .appendLine("sqls is installed.");
+    const actions = await vscode.window.showInformationMessage(
+      "sqls was successfully installed! Reload window to enable SQL language features.",
+      "Reload Window",
+    );
+    if (actions === "Reload Window") {
+      vscode.commands.executeCommand("workbench.action.reloadWindow");
+    }
+  },
+);

--- a/vsce/src/completion.ts
+++ b/vsce/src/completion.ts
@@ -1,0 +1,54 @@
+import { ORIGINAL_SCHEME, type SqlNode } from "@senken/config";
+import * as vscode from "vscode";
+
+export async function completionProvider(
+  virtualDocuments: Map<string, string>,
+  refresh: (
+    document: vscode.TextDocument,
+  ) => Promise<(SqlNode & { vFileName: string })[]>,
+) {
+  return {
+    async provideCompletionItems(
+      document: vscode.TextDocument,
+      position: vscode.Position,
+      _token: vscode.CancellationToken,
+      context: vscode.CompletionContext,
+    ) {
+      console.log(document.fileName); // TODO: to output channel
+      const sqlNodes = await refresh(document);
+      const sqlNode = sqlNodes.find(({ code_range: { start, end } }) => {
+        // in range
+        return (
+          (start.line < position.line && position.line < end.line) ||
+          (start.line === position.line &&
+            start.character <= position.character) ||
+          (end.line === position.line && position.character <= end.character)
+        );
+      });
+      if (!sqlNode) return [];
+
+      // Delegate LSP
+      // update virtual content
+      const offset = document.offsetAt(
+        new vscode.Position(
+          sqlNode.code_range.start.line,
+          sqlNode.code_range.start.character,
+        ),
+      );
+      const prefix = document.getText().slice(0, offset).replace(/[^\n]/g, " ");
+      const vContent = prefix + sqlNode.content;
+      virtualDocuments.set(sqlNode.vFileName, vContent);
+
+      // trigger completion on virtual file
+      const vDocUriString = `${ORIGINAL_SCHEME}://${sqlNode.vFileName}`;
+      const vDocUri = vscode.Uri.parse(vDocUriString);
+
+      return vscode.commands.executeCommand<vscode.CompletionList>(
+        "vscode.executeCompletionItemProvider",
+        vDocUri,
+        position,
+        context.triggerCharacter,
+      );
+    },
+  };
+}

--- a/vsce/src/extConfig.ts
+++ b/vsce/src/extConfig.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+
+type ExtConfig = {
+  formatOnSave: boolean;
+};
+
+export const extConfig: ExtConfig = {
+  formatOnSave: true,
+};
+
+export function getWorkspaceConfig(): ExtConfig {
+  const config = vscode.workspace.getConfiguration("sqlsurge");
+
+  const formatOnSave = config.get("formatOnSave");
+  if (typeof formatOnSave !== "boolean") {
+    throw new Error(
+      `formatOnSave must be a boolean, but got ${formatOnSave}(type:${typeof formatOnSave})`,
+    );
+  }
+
+  return { formatOnSave };
+}

--- a/vsce/src/extension.ts
+++ b/vsce/src/extension.ts
@@ -3,12 +3,13 @@ import { extractSqlListRs } from "@senken/sql-extraction-rs";
 import { extractSqlListTs } from "@senken/sql-extraction-ts";
 import * as ts from "typescript";
 import * as vscode from "vscode";
+import { command as commandInstallSqls } from "./commands/installSqls";
 import {
   type IncrementalLanguageService,
   createIncrementalLanguageService,
   createIncrementalLanguageServiceHost,
 } from "./service";
-import { client, findSqlsInPath, startSqlsClient } from "./startSqlsClient";
+import { client, startSqlsClient } from "./startSqlsClient";
 
 export async function activate(context: vscode.ExtensionContext) {
   startSqlsClient().catch(console.error);
@@ -26,52 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   });
 
-  const commands = [
-    vscode.commands.registerCommand("sqlsurge.installSqls", async () => {
-      let sqlsInPATH: vscode.Uri | undefined = undefined;
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: "Installing sqls...",
-        },
-        async () => {
-          vscode.window
-            .createOutputChannel("sqlsurge")
-            .appendLine("Installing sqls...");
-
-          // install sqls with command and wait for it
-          const terminal = vscode.window.createTerminal("install sqls");
-          terminal.show();
-          terminal.sendText("go install github.com/sqls-server/sqls@latest");
-          const timeout = 60 * 1000;
-          const start = Date.now();
-          while (Date.now() - start < timeout) {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            sqlsInPATH = await findSqlsInPath();
-            if (sqlsInPATH) {
-              break;
-            }
-          }
-        },
-      );
-      if (!sqlsInPATH) {
-        vscode.window.showErrorMessage("Failed to install sqls");
-        return;
-      }
-
-      // after installation
-      vscode.window
-        .createOutputChannel("sqlsurge")
-        .appendLine("sqls is installed.");
-      const actions = await vscode.window.showInformationMessage(
-        "sqls was successfully installed! Reload window to enable SQL language features.",
-        "Reload Window",
-      );
-      if (actions === "Reload Window") {
-        vscode.commands.executeCommand("workbench.action.reloadWindow");
-      }
-    }),
-  ];
+  const commands = [commandInstallSqls];
 
   const completion = {
     async provideCompletionItems(

--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -81,5 +81,23 @@ describe("SQLx Completion Test", () => {
   });
 });
 
-// TODO: Add more test cases
-describe("Formatting Test", () => {});
+describe("Formatting Test", () => {
+  it.only("Should be formatted with command", async () => {
+    const filePath = path.resolve(wsPath, "src", "main.rs");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    console.log(formattedText);
+    expect(formattedText).toMatchSnapshot();
+  });
+
+  it("Should be formatted with save if config is enabled", () => {});
+  it("Should be NOT formatted with save if config is disabled", () => {});
+});

--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -80,3 +80,6 @@ describe("SQLx Completion Test", () => {
     expect(kind).toBe(vscode.CompletionItemKind.Keyword);
   });
 });
+
+// TODO: Add more test cases
+describe("Formatting Test", () => {});

--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -82,7 +82,7 @@ describe("SQLx Completion Test", () => {
 });
 
 describe("Formatting Test", () => {
-  it.only("Should be formatted with command", async () => {
+  it("Should be formatted with command", async () => {
     const filePath = path.resolve(wsPath, "src", "main.rs");
     const docUri = vscode.Uri.file(filePath);
     const doc = await vscode.workspace.openTextDocument(docUri);
@@ -94,7 +94,6 @@ describe("Formatting Test", () => {
     await sleep(500);
 
     const formattedText = doc.getText();
-    console.log(formattedText);
     expect(formattedText).toMatchSnapshot();
   });
 

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -67,6 +67,16 @@ describe("Prisma Completion Test", () => {
 });
 
 describe("Formatting Test", () => {
+  afterEach(() => {
+    // reset config
+    vscode.workspace.getConfiguration("sqlsurge").update("formatOnSave", true);
+
+    // restore file
+    const mainRsPath = path.resolve(wsPath, "src", "index.ts");
+    const settingsJsonPath = path.resolve(wsPath, ".vscode", "settings.json");
+    execSync(`git restore ${mainRsPath} ${settingsJsonPath}`);
+  });
+
   it("Should be formatted with command", async () => {
     const filePath = path.resolve(wsPath, "src", "index.ts");
     const docUri = vscode.Uri.file(filePath);
@@ -81,6 +91,34 @@ describe("Formatting Test", () => {
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
   });
-  it("Should be formatted with save if config is enabled", () => {});
-  it("Should be NOT formatted with save if config is disabled", () => {});
+
+  it("Should be formatted with save if config is default(enabled)", async () => {
+    const filePath = path.resolve(wsPath, "src", "index.ts");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    await vscode.workspace.save(docUri);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
+
+  it("Should be NOT formatted with save if config is disabled", async () => {
+    const filePath = path.resolve(wsPath, "src", "index.ts");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // change config
+    await vscode.workspace
+      .getConfiguration("sqlsurge")
+      .update("formatOnSave", false);
+    await sleep(500);
+
+    await vscode.workspace.save(docUri);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
 });

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -66,5 +66,21 @@ describe("Prisma Completion Test", () => {
   });
 });
 
-// TODO: Add more test cases
-describe("Formatting Test", () => {});
+describe("Formatting Test", () => {
+  it("Should be formatted with command", async () => {
+    const filePath = path.resolve(wsPath, "src", "index.ts");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
+  it("Should be formatted with save if config is enabled", () => {});
+  it("Should be NOT formatted with save if config is disabled", () => {});
+});

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -65,3 +65,6 @@ describe("Prisma Completion Test", () => {
     expect(kind).toBe(vscode.CompletionItemKind.Keyword);
   });
 });
+
+// TODO: Add more test cases
+describe("Formatting Test", () => {});


### PR DESCRIPTION
This pull request adds a SQL formatter in TypeScript to the project. It includes the following changes:

- Refactored the installSqls command to install sqls and enable SQL language features

- Added a SQL formatter in TypeScript

- Updated SQL placeholder conversion in formatSql.ts

- Added a completionProvider function for SQL code completion

- Refactored SQL extraction functions in formatSql.ts

- Refactored SQL placeholder conversion and formatting in formatSql.ts

- Refactored SQL formatting and added SQL completion tests

- Updated SQL extraction functions

Fixes #7 
Fixes #8