### PR TITLE
Fix/not-save-on-format

### DIFF
--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -20,65 +20,64 @@ export async function commandFormatSqlProvider(
       const sqlNodes = await refresh(document);
       const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
 
-      const edit = new vscode.WorkspaceEdit();
-      sqlNodes.map((sqlNode) => {
-        // get prefix and suffix of space or new line
-        const prefixMatch = sqlNode.content.match(/^(\s*)/);
-        const prefix = prefixMatch ? prefixMatch[0] : "";
-        const suffixMatch = sqlNode.content.match(/(\s*)$/);
-        const suffix = suffixMatch ? suffixMatch[0] : "";
+      editor.edit((editBuilder) => {
+        sqlNodes.map((sqlNode) => {
+          // get prefix and suffix of space or new line
+          const prefixMatch = sqlNode.content.match(/^(\s*)/);
+          const prefix = prefixMatch ? prefixMatch[0] : "";
+          const suffixMatch = sqlNode.content.match(/(\s*)$/);
+          const suffix = suffixMatch ? suffixMatch[0] : "";
 
-        // convert place holder to dummy if there are any place holders
-        const placeHolderRegExp =
-          document.languageId === "typescript"
-            ? /\$\{.*\}/g
-            : document.languageId === "rust"
-              ? /(\$\d+|\?)/g
-              : undefined;
-        if (placeHolderRegExp === undefined) {
-          throw new Error("placeHolderRegExp is undefined");
-        }
+          // convert place holder to dummy if there are any place holders
+          const placeHolderRegExp =
+            document.languageId === "typescript"
+              ? /\$\{.*\}/g
+              : document.languageId === "rust"
+                ? /(\$\d+|\?)/g
+                : undefined;
+          if (placeHolderRegExp === undefined) {
+            throw new Error("placeHolderRegExp is undefined");
+          }
 
-        const placeHolders = sqlNode.content.match(placeHolderRegExp);
-        if (placeHolders) {
-          sqlNode.content = sqlNode.content.replaceAll(
-            placeHolderRegExp,
-            dummyPlaceHolder,
-          );
-        }
-
-        // get formatted content
-        const formattedContentWithDummy = format(sqlNode.content);
-
-        // reverse the place holders
-        let formattedContent = formattedContentWithDummy;
-        if (placeHolders) {
-          placeHolders.forEach((placeHolder, index) => {
-            formattedContent = formattedContent.replace(
+          const placeHolders = sqlNode.content.match(placeHolderRegExp);
+          if (placeHolders) {
+            sqlNode.content = sqlNode.content.replaceAll(
+              placeHolderRegExp,
               dummyPlaceHolder,
-              placeHolder,
             );
-          });
-        }
+          }
 
-        // replace with formatted content
-        edit.replace(
-          document.uri,
-          new vscode.Range(
-            new vscode.Position(
-              sqlNode.code_range.start.line,
-              sqlNode.code_range.start.character,
+          // get formatted content
+          const formattedContentWithDummy = format(sqlNode.content);
+
+          // reverse the place holders
+          let formattedContent = formattedContentWithDummy;
+          if (placeHolders) {
+            placeHolders.forEach((placeHolder, index) => {
+              formattedContent = formattedContent.replace(
+                dummyPlaceHolder,
+                placeHolder,
+              );
+            });
+          }
+
+          // replace with formatted content
+          editBuilder.replace(
+            new vscode.Range(
+              new vscode.Position(
+                sqlNode.code_range.start.line,
+                sqlNode.code_range.start.character,
+              ),
+              new vscode.Position(
+                sqlNode.code_range.end.line,
+                sqlNode.code_range.end.character,
+              ),
             ),
-            new vscode.Position(
-              sqlNode.code_range.end.line,
-              sqlNode.code_range.end.character,
-            ),
-          ),
-          prefix + formattedContent + suffix,
-        );
+            prefix + formattedContent + suffix,
+          );
+        });
       });
 
-      vscode.workspace.applyEdit(edit);
       logger.info("[commandFormatSqlProvider]", "Formatted");
     } catch (error) {
       logger.error(`[commandFormatSqlProvider] ${error}`);

--- a/vsce/test/helper.ts
+++ b/vsce/test/helper.ts
@@ -1,3 +1,19 @@
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function resetTestWorkspace(wsPath: string, testFilePath: string) {
+  // reset config
+  vscode.workspace.getConfiguration("sqlsurge").update("formatOnSave", true);
+
+  // restore file
+  const settingsJsonPath = path.resolve(wsPath, ".vscode", "settings.json");
+  execSync(`git restore ${testFilePath} ${settingsJsonPath}`);
+
+  // close active editor
+  await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
 }


### PR DESCRIPTION
This commit updates the test helper functions in the `helper.ts` file to include a new function called `resetTestWorkspace`. This function is responsible for resetting the test workspace by updating the configuration and restoring a file. It also closes the active editor.

The changes in this commit improve the reliability and stability of the test environment, ensuring that each test starts with a clean workspace.