### PR TITLE
Add SQL formatting options and improve SQLNode struct

### DIFF
--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -10,6 +10,7 @@ export type SqlNode = {
     };
   };
   content: string;
+  method_line: number; // 0-based
 };
 
 export const ORIGINAL_SCHEME = "sqlsurge";

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -10,7 +10,6 @@ export type SqlNode = {
     };
   };
   content: string;
-  quotation: string;
 };
 
 export const ORIGINAL_SCHEME = "sqlsurge";

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -10,6 +10,7 @@ export type SqlNode = {
     };
   };
   content: string;
+  quotation: string;
 };
 
 export const ORIGINAL_SCHEME = "sqlsurge";

--- a/sql-extraction/ts/src/index.ts
+++ b/sql-extraction/ts/src/index.ts
@@ -38,6 +38,7 @@ export function extractSqlListTs(sourceTxt: string): SqlNode[] {
           },
         },
         content: node.template.rawText ?? "",
+        quotation: "`",
       });
     }
     ts.forEachChild<void>(node, visit);

--- a/sql-extraction/ts/src/index.ts
+++ b/sql-extraction/ts/src/index.ts
@@ -12,7 +12,7 @@ export function extractSqlListTs(sourceTxt: string): SqlNode[] {
   return sqlNodes;
 
   /**
-   * visit nodes
+   * Visit nodes recursively
    * If find a tagged template expression with name "$queryRaw", push it to blocksNode
    */
   function visit(node: ts.Node): void {
@@ -22,6 +22,9 @@ export function extractSqlListTs(sourceTxt: string): SqlNode[] {
       node.tag.name.text === "$queryRaw" &&
       ts.isNoSubstitutionTemplateLiteral(node.template)
     ) {
+      const method_line = sourceFile.getLineAndCharacterOfPosition(
+        node.tag.pos,
+      ).line;
       const { line: startLine, character: startCharacter } =
         sourceFile.getLineAndCharacterOfPosition(node.template.pos + 1); // +1 is to remove the first back quote
       const { line: endLine, character: endCharacter } =
@@ -38,6 +41,7 @@ export function extractSqlListTs(sourceTxt: string): SqlNode[] {
           },
         },
         content: node.template.rawText ?? "",
+        method_line,
       });
     }
     ts.forEachChild<void>(node, visit);

--- a/sql-extraction/ts/src/index.ts
+++ b/sql-extraction/ts/src/index.ts
@@ -38,7 +38,6 @@ export function extractSqlListTs(sourceTxt: string): SqlNode[] {
           },
         },
         content: node.template.rawText ?? "",
-        quotation: "`",
       });
     }
     ts.forEachChild<void>(node, visit);

--- a/vsce/README.md
+++ b/vsce/README.md
@@ -1,4 +1,4 @@
-# sqlsurge
+# sqlsurge <!-- omit in toc -->
 
 [sqlsurge](https://marketplace.visualstudio.com/items?itemName=senken.sqlsurge) is a Visual Studio Code extension for SQL language server using [sqls](https://github.com/lighttiger2505/sqls). It works just **NOT ONLY with SQL files, but also with RAW SQL QUERIES on other languages such as TypeScript and Rust**.
 
@@ -8,18 +8,18 @@ Prisma Example in TypeScript:
 SQLx Example in Rust:
 ![Alt text](resources/screenshot-rs.png)
 
-## Features
+## Features <!-- omit in toc -->
 
-- Auto-Completion for SQL Syntax
-- Auto-Completion for Tables and Table Columns (requires sqls configuration)
-- Formatting
+- [Auto-Completion](#auto-completion)
+- [Formatting](#formatting)
+- [Supporting raw SQL query](#supporting-raw-sql-query)
 
-  - VSCode Command: `sqlsurge: Format SQL`
-  - Format on save by default. You can also change config to off by adding `sqlsurge.formatOnSave: false` in settings.json.
+### Auto-Completion
 
-- Supporting raw SQL query
-  - [Prisma](https://www.prisma.io/docs/orm/prisma-client/queries/raw-database-access/raw-queries) in TypeScript
-  - [SQLx](https://github.com/launchbadge/sqlx) in Rust
+These are the auto-completion items sqlsurge provides:
+
+- SQL keywords
+- Tables and columns (Required to be configured by `sqls config`)
 
 VSCode's quick suggestion(auto completion) in strings is disabled by default.
 It can be enabled by adding the following setting to settings.json.
@@ -30,21 +30,39 @@ It can be enabled by adding the following setting to settings.json.
 }
 ```
 
-## Requirements
+### Formatting
 
-- [**Golang**](https://golang.org/doc/install)
-- [**sqls**](https://github.com/sqls-server/sqls?tab=readme-ov-file#installation)
+- VSCode Command: `sqlsurge: Format SQL`
+- Settings
+  - `sqlsurge.formatOnSave`: Format SQL on save. Default is `true`.
+  - `sqlsurge.formatSql.indent`: Format SQL with indent. Default is `false`.
+  - `sqlsurge.formatSql.tabSize`: Tab size for SQL formatting. Default is `4`.
+
+As a formatter, sqlsurge use `sqls` for Vanilla SQL files, use [SQL Formatter](https://github.com/sql-formatter-org/sql-formatter) for raw SQL.
+
+### Supporting raw SQL query
+
+sqlsurge supports raw SQL queries in other languages such as TypeScript and Rust.
+Now it supports:
+
+- [Prisma](https://www.prisma.io/docs/orm/prisma-client/queries/raw-database-access/raw-queries) in TypeScript
+- [SQLx](https://github.com/launchbadge/sqlx) in Rust
+
+## Requirements <!-- omit in toc -->
+
+- [**Golang**](https://golang.org/doc/install) v1.22.2 or later
+- [**sqls**](https://github.com/sqls-server/sqls?tab=readme-ov-file#installation) v0.2.28 or later
   - There is sqls installation guide in the extension.
 
 To use completion for tables and columns, you need to configure the database connection by `sqls config` command.
 
-## TODOs
+## TODOs <!-- omit in toc -->
 
 - [x] Support for Prisma in TypeScript
 - [x] Support for SQLx in Rust
 - [x] Install guide for sqls
 - [x] Format SQL (Vanilla SQL: sqls, Raw SQL: [SQL Formatter](https://github.com/sql-formatter-org/sql-formatter))
-- [ ] Show quick info symbol
 - [ ] Support to custom raw SQL queries, not just Prisma and SQLx
+- [ ] Show quick info symbol
 - [ ] Execute SQL query
 - [ ] Show sqls config with tree view

--- a/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-rs/__snapshots__/extension.test.js.snap
@@ -105,6 +105,121 @@ ORDER BY id
 "
 `;
 
+exports[`Formatting Test Should be formatted with 2 tab size indent 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "      INSERT INTO
+        todos (description)
+      VALUES
+        ($1) RETURNING id",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+      UPDATE todos
+      SET
+        done = TRUE
+      WHERE
+        id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+      SELECT
+        id,
+        description,
+        done
+      FROM
+        todos
+      ORDER BY
+        id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
 exports[`Formatting Test Should be formatted with command 1`] = `
 "use sqlx::postgres::PgPool;
 use std::env;
@@ -159,9 +274,9 @@ async fn main() -> anyhow::Result<()> {
 async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
     let rec = sqlx::query!(
         "INSERT INTO
-  todos (description)
+    todos (description)
 VALUES
-  ($1) RETURNING id",
+    ($1) RETURNING id",
         description
     )
     .fetch_one(pool)
@@ -175,9 +290,9 @@ async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
         r#"
 UPDATE todos
 SET
-  done = TRUE
+    done = TRUE
 WHERE
-  id = $1
+    id = $1
         "#,
         id
     )
@@ -194,13 +309,128 @@ async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
         Todo,
         r#"
 SELECT
-  id,
-  description,
-  done
+    id,
+    description,
+    done
 FROM
-  todos
+    todos
 ORDER BY
-  id
+    id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
+exports[`Formatting Test Should be formatted with indent if config is enabled(default: off) 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "        INSERT INTO
+            todos (description)
+        VALUES
+            ($1) RETURNING id",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+        UPDATE todos
+        SET
+            done = TRUE
+        WHERE
+            id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+        SELECT
+            id,
+            description,
+            done
+        FROM
+            todos
+        ORDER BY
+            id
         "#
     )
     .fetch_all(pool)
@@ -274,9 +504,9 @@ async fn main() -> anyhow::Result<()> {
 async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
     let rec = sqlx::query!(
         "INSERT INTO
-  todos (description)
+    todos (description)
 VALUES
-  ($1) RETURNING id",
+    ($1) RETURNING id",
         description
     )
     .fetch_one(pool)
@@ -290,9 +520,9 @@ async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
         r#"
 UPDATE todos
 SET
-  done = TRUE
+    done = TRUE
 WHERE
-  id = $1
+    id = $1
         "#,
         id
     )
@@ -309,13 +539,13 @@ async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
         Todo,
         r#"
 SELECT
-  id,
-  description,
-  done
+    id,
+    description,
+    done
 FROM
-  todos
+    todos
 ORDER BY
-  id
+    id
         "#
     )
     .fetch_all(pool)

--- a/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
+++ b/vsce/out/test/suite-ts/__snapshots__/extension.test.js.snap
@@ -37,6 +37,40 @@ main()
 "
 `;
 
+exports[`Formatting Test Should be formatted with 2 tab size indent 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`    SELECT
+      *
+    FROM
+      todos
+    WHERE
+      id = 1;\`;
+  await prisma.$queryRaw\`
+    INSERT INTO
+      todos (id, description, done)
+    VALUES
+      (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
 exports[`Formatting Test Should be formatted with command 1`] = `
 "import { PrismaClient } from "@prisma/client";
 
@@ -44,16 +78,50 @@ const prisma = new PrismaClient();
 
 async function main() {
   const todo = await prisma.$queryRaw\`SELECT
-  *
+    *
 FROM
-  todos
+    todos
 WHERE
-  id = 1;\`;
+    id = 1;\`;
+  await prisma.$queryRaw\`
+INSERT INTO
+    todos (id, description, done)
+VALUES
+    (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
+exports[`Formatting Test Should be formatted with indent if config is enabled(default: off) 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`    SELECT
+        *
+    FROM
+        todos
+    WHERE
+        id = 1;\`;
   await prisma.$queryRaw\`
     INSERT INTO
-  todos (id, description, done)
-VALUES
-  (1, "todo description", TRUE);
+        todos (id, description, done)
+    VALUES
+        (1, "todo description", TRUE);
     \`;
   console.log(todo);
 }
@@ -78,16 +146,16 @@ const prisma = new PrismaClient();
 
 async function main() {
   const todo = await prisma.$queryRaw\`SELECT
-  *
+    *
 FROM
-  todos
+    todos
 WHERE
-  id = 1;\`;
+    id = 1;\`;
   await prisma.$queryRaw\`
-    INSERT INTO
-  todos (id, description, done)
+INSERT INTO
+    todos (id, description, done)
 VALUES
-  (1, "todo description", TRUE);
+    (1, "todo description", TRUE);
     \`;
   console.log(todo);
 }

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -52,11 +52,6 @@
           "type": "boolean",
           "default": true,
           "description": "Format SQL on save."
-        },
-        "sqlsurge.formatSqlWithIndent": {
-          "type": "boolean",
-          "default": false,
-          "description": "Format SQL with indent."
         }
       }
     },

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -53,10 +53,15 @@
           "default": true,
           "description": "Format SQL on save."
         },
-        "sqlsurge.formatSqlWithIndent": {
+        "sqlsurge.formatSql.indent": {
           "type": "boolean",
           "default": false,
           "description": "Format SQL with indent."
+        },
+        "sqlsurge.formatSql.indentSize": {
+          "type": "number",
+          "default": 4,
+          "description": "Indent size for SQL formatting."
         }
       }
     },

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -58,7 +58,7 @@
           "default": false,
           "description": "Format SQL with indent."
         },
-        "sqlsurge.formatSql.indentSize": {
+        "sqlsurge.formatSql.tabSize": {
           "type": "number",
           "default": 4,
           "description": "Indent size for SQL formatting."

--- a/vsce/package.json
+++ b/vsce/package.json
@@ -52,6 +52,11 @@
           "type": "boolean",
           "default": true,
           "description": "Format SQL on save."
+        },
+        "sqlsurge.formatSqlWithIndent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Format SQL with indent."
         }
       }
     },

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -3,85 +3,140 @@ import type { SqlNode } from "@senken/config";
 import { format } from "sql-formatter";
 import * as vscode from "vscode";
 
+// TODO: convert to class for logger
 export async function commandFormatSqlProvider(
   logger: vscode.LogOutputChannel,
-  refresh: (
-    document: vscode.TextDocument,
-  ) => Promise<(SqlNode & { vFileName: string })[]>,
+  refresh: RefreshFunc,
 ) {
-  return vscode.commands.registerCommand("sqlsurge.formatSql", async () => {
-    try {
-      logger.info("[commandFormatSqlProvider]", "Formatting...");
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        return;
-      }
-      const document = editor.document;
-      const sqlNodes = await refresh(document);
-      const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
+  return vscode.commands.registerCommand("sqlsurge.formatSql", () =>
+    formatSql(logger, refresh),
+  );
+}
 
-      editor.edit((editBuilder) => {
-        sqlNodes.map((sqlNode) => {
-          // get prefix and suffix of space or new line
-          const prefixMatch = sqlNode.content.match(/^(\s*)/);
-          const prefix = prefixMatch ? prefixMatch[0] : "";
-          const suffixMatch = sqlNode.content.match(/(\s*)$/);
-          const suffix = suffixMatch ? suffixMatch[0] : "";
+type RefreshFunc = (
+  document: vscode.TextDocument,
+) => Promise<(SqlNode & { vFileName: string })[]>;
 
-          // convert place holder to dummy if there are any place holders
-          const placeHolderRegExp =
-            document.languageId === "typescript"
-              ? /\$\{.*\}/g
-              : document.languageId === "rust"
-                ? /(\$\d+|\?)/g
-                : undefined;
-          if (placeHolderRegExp === undefined) {
-            throw new Error("placeHolderRegExp is undefined");
-          }
-
-          const placeHolders = sqlNode.content.match(placeHolderRegExp);
-          if (placeHolders) {
-            sqlNode.content = sqlNode.content.replaceAll(
-              placeHolderRegExp,
-              dummyPlaceHolder,
-            );
-          }
-
-          // get formatted content
-          const formattedContentWithDummy = format(sqlNode.content);
-
-          // reverse the place holders
-          let formattedContent = formattedContentWithDummy;
-          if (placeHolders) {
-            placeHolders.forEach((placeHolder, index) => {
-              formattedContent = formattedContent.replace(
-                dummyPlaceHolder,
-                placeHolder,
-              );
-            });
-          }
-
-          // replace with formatted content
-          editBuilder.replace(
-            new vscode.Range(
-              new vscode.Position(
-                sqlNode.code_range.start.line,
-                sqlNode.code_range.start.character,
-              ),
-              new vscode.Position(
-                sqlNode.code_range.end.line,
-                sqlNode.code_range.end.character,
-              ),
-            ),
-            prefix + formattedContent + suffix,
-          );
-        });
-      });
-
-      logger.info("[commandFormatSqlProvider]", "Formatted");
-    } catch (error) {
-      logger.error(`[commandFormatSqlProvider] ${error}`);
-      vscode.window.showErrorMessage(`[commandFormatSqlProvider] ${error}`);
+async function formatSql(
+  logger: vscode.LogOutputChannel,
+  refresh: RefreshFunc,
+): Promise<void> {
+  try {
+    logger.info("[commandFormatSqlProvider]", "Formatting...");
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
     }
-  });
+    const document = editor.document;
+    const sqlNodes = await refresh(document);
+    const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
+
+    editor.edit((editBuilder) => {
+      sqlNodes.map((sqlNode) => {
+        // get prefix and suffix of space or new line
+        const prefixMatch = sqlNode.content.match(/^(\s*)/);
+        const prefix = prefixMatch ? prefixMatch[0] : "";
+        const suffixMatch = sqlNode.content.match(/(\s*)$/);
+        const suffix = suffixMatch ? suffixMatch[0] : "";
+
+        // convert place holder to dummy if there are any place holders
+        const placeHolderRegExp =
+          document.languageId === "typescript"
+            ? /\$\{.*\}/g
+            : document.languageId === "rust"
+              ? /(\$\d+|\?)/g
+              : undefined;
+        if (placeHolderRegExp === undefined) {
+          throw new Error("placeHolderRegExp is undefined");
+        }
+
+        const placeHolders = sqlNode.content.match(placeHolderRegExp);
+        if (placeHolders) {
+          sqlNode.content = sqlNode.content.replaceAll(
+            placeHolderRegExp,
+            dummyPlaceHolder,
+          );
+        }
+
+        // get formatted content
+        const formattedContentWithDummy = format(sqlNode.content);
+
+        // reverse the place holders
+        let formattedContent = formattedContentWithDummy;
+        if (placeHolders) {
+          placeHolders.forEach((placeHolder, index) => {
+            formattedContent = formattedContent.replace(
+              dummyPlaceHolder,
+              placeHolder,
+            );
+          });
+        }
+
+        // get vscode settings for indent
+        const formatSqlWithIndent = vscode.workspace
+          .getConfiguration("sqlsurge")
+          .get("formatSql") as {
+          indent: boolean;
+          indentSize: number;
+        };
+
+        if (formatSqlWithIndent.indent) {
+          formattedContent = indentedContent(
+            formattedContent,
+            sqlNode.method_line,
+            formatSqlWithIndent.indentSize,
+          );
+        }
+
+        // replace with formatted content
+        editBuilder.replace(
+          new vscode.Range(
+            new vscode.Position(
+              sqlNode.code_range.start.line,
+              sqlNode.code_range.start.character,
+            ),
+            new vscode.Position(
+              sqlNode.code_range.end.line,
+              sqlNode.code_range.end.character,
+            ),
+          ),
+          prefix + formattedContent + suffix,
+        );
+      });
+    });
+
+    logger.info("[commandFormatSqlProvider]", "Formatted");
+  } catch (error) {
+    logger.error(`[commandFormatSqlProvider] ${error}`);
+    vscode.window.showErrorMessage(`[commandFormatSqlProvider] ${error}`);
+  }
+}
+
+function indentedContent(
+  content: string,
+  methodLine: SqlNode["method_line"],
+  indentSize: number,
+): string {
+  const lineText =
+    vscode.window.activeTextEditor?.document.lineAt(methodLine).text;
+  if (!lineText) {
+    return content;
+  }
+
+  const indents = lineText.match(/^(\s*)/)?.[0];
+  if (!indents) {
+    return content;
+  }
+
+  if (indents.length % indentSize !== 0) {
+    // TODO: log
+    throw new Error("indent size should be multiple of indents length");
+  }
+
+  // FIXME: first line is always plus one indent
+  const oneLevelDown = indents.slice(0, indentSize);
+  return content
+    .split("\n")
+    .map((line) => indents + oneLevelDown + line)
+    .join("\n");
 }

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -57,17 +57,19 @@ async function formatSql(
           );
         }
 
-        const config = vscode.workspace
+        const isEnabledIndent = vscode.workspace
           .getConfiguration("sqlsurge")
-          .get("formatSql") as {
-          indent: boolean;
-          tabSize: number;
-        };
-        // TODO: config validation
+          .get("formatSql.indent");
+        const defaultTabSize = 4;
+        const tabSize =
+          (vscode.workspace
+            .getConfiguration("sqlsurge")
+            .get("formatSql.tabSize") as number) ?? defaultTabSize;
+        // TODO: config validation, and get from package.json
 
         // get formatted content
         const formattedContentWithDummy = format(sqlNode.content, {
-          tabWidth: config.tabSize,
+          tabWidth: tabSize,
         });
 
         // reverse the place holders
@@ -82,11 +84,11 @@ async function formatSql(
         }
 
         // add indent if config is enabled
-        if (config.indent) {
+        if (isEnabledIndent) {
           formattedContent = indentedContent(
             formattedContent,
             sqlNode.method_line,
-            config.tabSize,
+            tabSize,
           );
         }
 
@@ -128,11 +130,6 @@ function indentedContent(
   const indents = lineText.match(/^(\s*)/)?.[0];
   if (!indents) {
     return content;
-  }
-
-  if (indents.length % tabSize !== 0) {
-    // TODO: log
-    throw new Error("indent size should be multiple of indents length");
   }
 
   const oneLevelDown = indents.slice(0, tabSize);

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -35,7 +35,7 @@ async function formatSql(
       sqlNodes.map((sqlNode) => {
         // get prefix and suffix of space or new line
         const prefixMatch = sqlNode.content.match(/^(\s*)/);
-        const prefix = prefixMatch ? prefixMatch[0] : "";
+        const prefix = prefixMatch ? prefixMatch[0].replace(/ +$/g, "") : "";
         const suffixMatch = sqlNode.content.match(/(\s*)$/);
         const suffix = suffixMatch ? suffixMatch[0] : "";
 
@@ -72,14 +72,13 @@ async function formatSql(
           });
         }
 
-        // get vscode settings for indent
+        // add indent if config is enabled
         const formatSqlWithIndent = vscode.workspace
           .getConfiguration("sqlsurge")
           .get("formatSql") as {
           indent: boolean;
           indentSize: number;
         };
-
         if (formatSqlWithIndent.indent) {
           formattedContent = indentedContent(
             formattedContent,
@@ -133,7 +132,6 @@ function indentedContent(
     throw new Error("indent size should be multiple of indents length");
   }
 
-  // FIXME: first line is always plus one indent
   const oneLevelDown = indents.slice(0, indentSize);
   return content
     .split("\n")

--- a/vsce/src/extension.ts
+++ b/vsce/src/extension.ts
@@ -138,6 +138,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 },
               },
               content: sqlNode.content,
+              quotation: sqlNode.quotation,
             };
           });
           break;

--- a/vsce/test/helper.ts
+++ b/vsce/test/helper.ts
@@ -7,13 +7,10 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 export async function resetTestWorkspace(wsPath: string, testFilePath: string) {
-  // reset config
-  vscode.workspace.getConfiguration("sqlsurge").update("formatOnSave", true);
-
   // restore file
   const settingsJsonPath = path.resolve(wsPath, ".vscode", "settings.json");
   execSync(`git restore ${testFilePath} ${settingsJsonPath}`);
 
   // close active editor
-  await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+  await vscode.commands.executeCommand("workbench.action.closeAllGroups");
 }

--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -129,6 +129,7 @@ describe("Formatting Test", () => {
     const editor = await vscode.window.showTextDocument(doc);
 
     await vscode.workspace.save(docUri);
+    await sleep(500);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();

--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -144,11 +144,51 @@ describe("Formatting Test", () => {
     await vscode.workspace
       .getConfiguration("sqlsurge")
       .update("formatOnSave", false);
-    await sleep(500);
 
     await vscode.workspace.save(docUri);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();
+  });
+
+  it("Should be formatted with indent if config is enabled(default: off)", async () => {
+    const filePath = path.resolve(wsPath, "src", "main.rs");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // change config
+    await vscode.workspace
+      .getConfiguration("sqlsurge")
+      .update("formatSql.indent", true);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
+
+  it("Should be formatted with 2 tab size indent", async () => {
+    const filePath = path.resolve(wsPath, "src", "main.rs");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // change config
+    await vscode.workspace
+      .getConfiguration("sqlsurge", vscode.workspace.workspaceFolders?.[0].uri)
+      .update("formatSql.indent", true);
+    await vscode.workspace
+      .getConfiguration("sqlsurge")
+      .update("formatSql.tabSize", 2);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
   });
 });

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -97,6 +97,7 @@ describe("Formatting Test", () => {
     const editor = await vscode.window.showTextDocument(doc);
 
     await vscode.workspace.save(docUri);
+    await sleep(500);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -119,4 +119,45 @@ describe("Formatting Test", () => {
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();
   });
+
+  it("Should be formatted with indent if config is enabled(default: off)", async () => {
+    const filePath = path.resolve(wsPath, "src", "index.ts");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // change config
+    await vscode.workspace
+      .getConfiguration("sqlsurge")
+      .update("formatSql.indent", true);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
+
+  it("Should be formatted with 2 tab size indent", async () => {
+    const filePath = path.resolve(wsPath, "src", "index.ts");
+    const docUri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+
+    // change config
+    await vscode.workspace
+      .getConfiguration("sqlsurge", vscode.workspace.workspaceFolders?.[0].uri)
+      .update("formatSql.indent", true);
+    await vscode.workspace
+      .getConfiguration("sqlsurge")
+      .update("formatSql.tabSize", 2);
+
+    // execute command
+    await vscode.commands.executeCommand("sqlsurge.formatSql");
+    await sleep(500);
+
+    const formattedText = doc.getText();
+    expect(formattedText).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
close #49
This pull request includes several changes related to SQL formatting and the SQLNode struct.

The commits in this pull request add new SQL formatting options to the package.json file, allowing users to customize the indentation and tab size for SQL code. Additionally, the formatSql.ts file has been updated to use the "tabSize" property instead of the deprecated "indent" property for SQL formatting. These changes improve the consistency and flexibility of the SQL formatting options.

Furthermore, the SQLNode struct has been updated in multiple files to include a new field called "method_line". This field represents the line number where the SQL code is located within the method or function, providing useful information for debugging and analysis.

Overall, this pull request enhances the SQL formatting capabilities and improves the accuracy and context of the SQL extraction process.