### PR TITLE
refactor: Improve reliability of formatting tests

### DIFF
--- a/vsce/test/suite-rs/extension.test.ts
+++ b/vsce/test/suite-rs/extension.test.ts
@@ -113,10 +113,13 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
 
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
@@ -128,8 +131,9 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    await sleep(1000);
     await vscode.workspace.save(docUri);
-    await sleep(500);
+    await sleep(1000);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();
@@ -141,12 +145,15 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge")
       .update("formatOnSave", false);
 
     await vscode.workspace.save(docUri);
+    await sleep(1000);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();
@@ -158,6 +165,8 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge")
@@ -165,7 +174,7 @@ describe("Formatting Test", () => {
 
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
@@ -177,6 +186,8 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge", vscode.workspace.workspaceFolders?.[0].uri)
@@ -187,7 +198,7 @@ describe("Formatting Test", () => {
 
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();

--- a/vsce/test/suite-ts/extension.test.ts
+++ b/vsce/test/suite-ts/extension.test.ts
@@ -81,10 +81,13 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
 
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
@@ -96,8 +99,11 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     await vscode.workspace.save(docUri);
-    await sleep(500);
+    await sleep(1000);
 
     const newText = fs.readFileSync(filePath, "utf8");
     expect(newText).toMatchSnapshot();
@@ -109,11 +115,14 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge")
       .update("formatOnSave", false);
-    await sleep(500);
+    await sleep(1000);
 
     await vscode.workspace.save(docUri);
 
@@ -127,6 +136,9 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge")
@@ -134,7 +146,7 @@ describe("Formatting Test", () => {
 
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
@@ -146,6 +158,9 @@ describe("Formatting Test", () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
     const editor = await vscode.window.showTextDocument(doc);
 
+    // Wait for server activation
+    await sleep(1000);
+
     // change config
     await vscode.workspace
       .getConfiguration("sqlsurge", vscode.workspace.workspaceFolders?.[0].uri)
@@ -156,7 +171,7 @@ describe("Formatting Test", () => {
 
     // execute command
     await vscode.commands.executeCommand("sqlsurge.formatSql");
-    await sleep(500);
+    await sleep(1000);
 
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();


### PR DESCRIPTION
Add sleep before saving document in test files to ensure document is fully updated before performing assertions on its contents. This change adds a sleep of 1000 milliseconds before saving the document in the test files `extension.test.ts`. By adding this sleep, we improve the reliability of the formatting tests.