### PR TITLE
Fix SQL formatting function in the case of empty sql content and test suite

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,7 @@
   },
   "rust-analyzer.linkedProjects": [
     "./sql-extraction/rs/Cargo.toml",
-    "./vsce/test-workspace-rs/Cargo.toml"
+    "./vsce-test/test-workspace-rs/Cargo.toml"
   ],
   "github-actions.workflows.pinned.workflows": [
     ".github/workflows/e2e-test.yaml",

--- a/biome.json
+++ b/biome.json
@@ -17,17 +17,19 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noExplicitAny": "warn"
+        "noExplicitAny": "warn",
+        "noConsoleLog": "error"
       },
       "style": {
         "noParameterAssign": "warn",
         "noNonNullAssertion": "warn"
       }
-    }
+    },
+    "ignore": ["test-workspace*"]
   },
   "json": {
     "parser": {
-      "allowTrailingCommas": false,
+      "allowTrailingCommas": true,
       "allowComments": true
     }
   }

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -15,9 +15,9 @@ pre-commit:
     biome:
       glob: "*.{js,ts,jsx,tsx,json,css,scss}"
       run: |
-        bunx biome check --apply {staged_files} && git add {staged_files}
+        pnpm biome check --apply {staged_files} && git add {staged_files}
     cspell:
       glob: "*"
       run: |
         # check file name
-        git diff --name-only --cached | bunx cspell --no-progress --show-context stdin --cache
+        git diff --name-only --cached | pnpm cspell --no-progress --show-context stdin --cache

--- a/vsce-test/package.json
+++ b/vsce-test/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@senken/vsce-test",
   "scripts": {
-    "test:e2e": "tsc -p . && node ./out/runTest.js",
+    "test:e2e": "tsc && node ./out/runTest.js",
     "test:e2e:bg": "xvfb-run -a pnpm test:e2e"
   },
   "devDependencies": {
     "@types/vscode": "^1.90.0",
     "@vscode/test-electron": "^2.4.0"
+  },
+  "jest": {
+    "snapshotResolver": "<rootDir>/test/snapshotResolver.js"
   }
 }

--- a/vsce-test/test/helper.ts
+++ b/vsce-test/test/helper.ts
@@ -14,8 +14,9 @@ export async function resetTestWorkspace(
   const settingsJsonPath = path.resolve(wsPath, ".vscode", "settings.json");
   const testFilePathJoinedWithSpace = testFilePaths.join(" ");
 
+  // restore saved files
   execSync(`git restore ${testFilePathJoinedWithSpace} ${settingsJsonPath}`);
 
-  // close active editor
-  await vscode.commands.executeCommand("workbench.action.closeAllGroups");
+  // revert unsaved changes
+  await vscode.commands.executeCommand("workbench.action.files.revert");
 }

--- a/vsce-test/test/snapshotResolver.js
+++ b/vsce-test/test/snapshotResolver.js
@@ -1,0 +1,26 @@
+module.exports = {
+  /**
+   * @param {string} testPath
+   * @param {string} snapshotExtension
+   */
+  resolveSnapshotPath: (testPath, snapshotExtension) =>
+    testPath.replace(/\/out\//, "/test/").replace(/\.js/, ".ts") +
+    snapshotExtension,
+
+  /**
+   * @param {string} snapshotFilePath
+   * @param {string} snapshotExtension
+   */
+  resolveTestPath: (snapshotFilePath, snapshotExtension) =>
+    snapshotFilePath.slice(0, -snapshotExtension.length),
+
+  // Example test path, used for preflight consistency check of the implementation above
+  testPathForConsistencyCheck: "some/__tests__/example.test.ts",
+};
+
+// Results in:
+// .
+// ├── test
+// │   ├── suite-ts
+// │   │   ├── extension.test.ts
+// │   │   ├── extension.test.ts.snap

--- a/vsce-test/test/suite-rs/extension.test.ts
+++ b/vsce-test/test/suite-rs/extension.test.ts
@@ -275,4 +275,39 @@ describe("Formatting Test", () => {
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
   });
+
+  it.each`
+    desc                      | content
+    ${"empty"}                | ${""}
+    ${"one space"}            | ${" "}
+    ${"one new line"}         | ${"\n"}
+    ${"spaces and new lines"} | ${"\n  \n  \n"}
+  `(
+    "Should NOT be formatted with empty content: $desc",
+    async ({ content }) => {
+      const filePath = path.resolve(wsPath, "src", "main.rs");
+      const docUri = vscode.Uri.file(filePath);
+      const doc = await vscode.workspace.openTextDocument(docUri);
+      const editor = await vscode.window.showTextDocument(doc);
+
+      await sleep(1000);
+
+      // change config
+      const replaceRange = new vscode.Range(
+        new vscode.Position(52, 9),
+        new vscode.Position(52, 69),
+      );
+      await editor.edit((editBuilder) => {
+        editBuilder.replace(replaceRange, content);
+      });
+
+      // execute command
+      await vscode.commands.executeCommand("sqlsurge.formatSql");
+      await sleep(1000);
+
+      // execute command
+      const formattedText = doc.getText();
+      expect(formattedText).toMatchSnapshot();
+    },
+  );
 });

--- a/vsce-test/test/suite-rs/extension.test.ts.snap
+++ b/vsce-test/test/suite-rs/extension.test.ts.snap
@@ -1,5 +1,457 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Formatting Test Should NOT be formatted with empty content: empty 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+    done = TRUE
+WHERE
+    id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+    id,
+    description,
+    done
+FROM
+    todos
+ORDER BY
+    id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: one new line 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "
+",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+    done = TRUE
+WHERE
+    id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+    id,
+    description,
+    done
+FROM
+    todos
+ORDER BY
+    id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: one space 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        " ",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+    done = TRUE
+WHERE
+    id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+    id,
+    description,
+    done
+FROM
+    todos
+ORDER BY
+    id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: spaces and new lines 1`] = `
+"use sqlx::postgres::PgPool;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+struct Todo {
+    id: i64,
+    description: String,
+    done: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{description}'");
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {todo_id}");
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {id} as done");
+            if complete_todo(&pool, id).await? {
+                println!("Todo {id} is marked as done");
+            } else {
+                println!("Invalid id {id}");
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        "
+  
+  
+",
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET
+    done = TRUE
+WHERE
+    id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    // query_as!に書き変え
+    let recs = sqlx::query_as!(
+        Todo,
+        r#"
+SELECT
+    id,
+    description,
+    done
+FROM
+    todos
+ORDER BY
+    id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}
+"
+`;
+
 exports[`Formatting Test Should be NOT formatted with save if config is disabled 1`] = `
 "use sqlx::postgres::PgPool;
 use std::env;

--- a/vsce-test/test/suite-ts/extension.test.ts
+++ b/vsce-test/test/suite-ts/extension.test.ts
@@ -250,4 +250,39 @@ describe("Formatting Test", () => {
     const formattedText = doc.getText();
     expect(formattedText).toMatchSnapshot();
   });
+
+  it.each`
+    desc                      | content
+    ${"empty"}                | ${""}
+    ${"one space"}            | ${" "}
+    ${"one new line"}         | ${"\n"}
+    ${"spaces and new lines"} | ${"\n  \n  \n"}
+  `(
+    "Should NOT be formatted with empty content: $desc",
+    async ({ content }) => {
+      const filePath = path.resolve(wsPath, "src", "index.ts");
+      const docUri = vscode.Uri.file(filePath);
+      const doc = await vscode.workspace.openTextDocument(docUri);
+      const editor = await vscode.window.showTextDocument(doc);
+
+      await sleep(1000);
+
+      // change config
+      const replaceRange = new vscode.Range(
+        new vscode.Position(5, 38),
+        new vscode.Position(5, 71),
+      );
+      await editor.edit((editBuilder) => {
+        editBuilder.replace(replaceRange, content);
+      });
+
+      // execute command
+      await vscode.commands.executeCommand("sqlsurge.formatSql");
+      await sleep(1000);
+
+      // execute command
+      const formattedText = doc.getText();
+      expect(formattedText).toMatchSnapshot();
+    },
+  );
 });

--- a/vsce-test/test/suite-ts/extension.test.ts
+++ b/vsce-test/test/suite-ts/extension.test.ts
@@ -25,7 +25,6 @@ afterEach(async () => {
 describe("Install sqls if not found in PATH", () => {
   test("Should find sqls in PATH", async () => {
     const sqlsVersion = execSync("sqls --version").toString();
-    console.log(sqlsVersion);
     expect(sqlsVersion).not.toBe("");
   });
 });

--- a/vsce-test/test/suite-ts/extension.test.ts.snap
+++ b/vsce-test/test/suite-ts/extension.test.ts.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Formatting Test Should NOT be formatted with empty content: empty 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`\`;
+  await prisma.$queryRaw\`
+INSERT INTO
+    todos (id, description, done)
+VALUES
+    (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: one new line 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`
+\`;
+  await prisma.$queryRaw\`
+INSERT INTO
+    todos (id, description, done)
+VALUES
+    (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: one space 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\` \`;
+  await prisma.$queryRaw\`
+INSERT INTO
+    todos (id, description, done)
+VALUES
+    (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
+exports[`Formatting Test Should NOT be formatted with empty content: spaces and new lines 1`] = `
+"import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todo = await prisma.$queryRaw\`
+  
+  
+\`;
+  await prisma.$queryRaw\`
+INSERT INTO
+    todos (id, description, done)
+VALUES
+    (1, "todo description", TRUE);
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+"
+`;
+
 exports[`Formatting Test Should be NOT formatted with save if config is disabled 1`] = `
 "import { PrismaClient } from "@prisma/client";
 

--- a/vsce/src/commands/formatSql.ts
+++ b/vsce/src/commands/formatSql.ts
@@ -31,7 +31,17 @@ async function formatSql(refresh: RefreshFunc): Promise<void> {
     const dummyPlaceHolder = '"SQLSURGE_DUMMY"';
 
     editor.edit((editBuilder) => {
-      sqlNodes.map((sqlNode) => {
+      for (const sqlNode of sqlNodes) {
+        logger.debug("[formatSql]", "Formatting", sqlNode);
+        if (sqlNode.content.match(/^\s*$/)) {
+          logger.debug(
+            "[formatSql]",
+            "Skip formatting for empty content",
+            sqlNode,
+          );
+          continue;
+        }
+
         // get prefix and suffix of space or new line
         const prefix =
           sqlNode.content
@@ -67,7 +77,7 @@ async function formatSql(refresh: RefreshFunc): Promise<void> {
             "Skip formatting for typescript string 1 line",
             sqlNode,
           );
-          return;
+          continue;
         }
 
         // convert place holder to dummy if there are any place holders
@@ -92,7 +102,7 @@ async function formatSql(refresh: RefreshFunc): Promise<void> {
         const isEnabledIndent = getWorkspaceConfig("formatSql.indent");
         const tabSize = getWorkspaceConfig("formatSql.tabSize");
         if (tabSize === undefined) {
-          return;
+          continue;
         }
 
         // get formatted content
@@ -134,7 +144,7 @@ async function formatSql(refresh: RefreshFunc): Promise<void> {
           ),
           prefix + formattedContent + suffix,
         );
-      });
+      }
     });
 
     logger.info("[commandFormatSqlProvider]", "Formatted");

--- a/vsce/src/extension.ts
+++ b/vsce/src/extension.ts
@@ -131,7 +131,6 @@ export async function activate(context: vscode.ExtensionContext) {
             config = undefined;
           }
           sqlNodes = await extractSqlListRs(rawContent, config?.configs);
-          console.log(sqlNodes);
           break;
         }
         default:


### PR DESCRIPTION
This pull request includes updates to the SQL formatting function and the corresponding test suite. The changes made are as follows:

- Updated the SQL formatting function to skip empty content.

- Refactored the test suite for SQL formatting to handle empty content.

- Reverted unsaved changes in the test workspace.

- Updated the Jest snapshotResolver configuration for SQL formatting tests.

These updates improve the functionality and reliability of the SQL formatting feature.