### PR TITLE
fix identity tag template literal not working bug and add unit tests

### DIFF
--- a/example-workspaces/ts/package.json
+++ b/example-workspaces/ts/package.json
@@ -1,11 +1,13 @@
 {
   "name": "test-workspace-ts",
   "devDependencies": {
+    "@types/bun": "^1.2.21",
     "prisma": "6.3.0",
     "sql-formatter": "^15.4.2",
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@prisma/client": "6.3.0"
+    "@prisma/client": "6.3.0",
+    "bun": "^1.2.21"
   }
 }

--- a/example-workspaces/ts/src/bun.ts
+++ b/example-workspaces/ts/src/bun.ts
@@ -1,0 +1,29 @@
+import { sql } from "bun";
+
+async function main() {
+  const todo = await sql`SELECT * FROM todos WHERE id = 1;\`;
+  await sql\`
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    `;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/sql-extraction/ts/src/index.test.ts
+++ b/sql-extraction/ts/src/index.test.ts
@@ -71,6 +71,148 @@ main()
         },
       ]);
     });
+    it("should work with Prisma with query alias", () => {
+      const result = extractSqlListTs(
+        `
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const query = prisma.$queryRaw;
+  const todo = await query\`SELECT * FROM todos WHERE id = 1;\`;
+  await query\`
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+        `,
+        [{ functionName: "query", sqlArgNo: 0, isTemplateLiteral: true }],
+      );
+
+      expect(result).toStrictEqual([
+        {
+          code_range: {
+            start: { line: 7, character: 27 },
+            end: { line: 7, character: 60 },
+          },
+          content: "SELECT * FROM todos WHERE id = 1;",
+          method_line: 7,
+        },
+        {
+          code_range: {
+            start: { line: 8, character: 14 },
+            end: { line: 21, character: 4 },
+          },
+          content: `
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    `,
+          method_line: 8,
+        },
+      ]);
+    });
+    it("should work with Bun", () => {
+      const result = extractSqlListTs(
+        `
+import { sql } from "bun";
+
+async function main() {
+  const todo = await sql\`SELECT * FROM todos WHERE id = 1;\`;
+  await sql\`
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    \`;
+  console.log(todo);
+}
+
+main()
+  .then(async () => {
+    console.log("Disconnected");
+  })
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  });
+`,
+        [{ functionName: "sql", sqlArgNo: 0, isTemplateLiteral: true }],
+      );
+
+      expect(result).toStrictEqual([
+        {
+          code_range: {
+            start: { line: 4, character: 25 },
+            end: { line: 4, character: 58 },
+          },
+          content: "SELECT * FROM todos WHERE id = 1;",
+          method_line: 4,
+        },
+        {
+          code_range: {
+            start: { line: 5, character: 12 },
+            end: { line: 18, character: 4 },
+          },
+          content: `
+    INSERT INTO todos
+    (
+        id,
+        description,
+        done
+    )
+    VALUES
+    (
+        1,
+        "todo description",
+        TRUE
+    );
+    `,
+          method_line: 5,
+        },
+      ]);
+    });
+
     it("should work with TypeORM", () => {
       const result = extractSqlListTs(
         `

--- a/sql-extraction/ts/src/index.ts
+++ b/sql-extraction/ts/src/index.ts
@@ -116,8 +116,9 @@ export function extractSqlListTs(
       if (
         c.isTemplateLiteral &&
         ts.isTaggedTemplateExpression(node) &&
-        ts.isPropertyAccessExpression(node.tag) &&
-        node.tag.name.text === c.functionName &&
+        ((ts.isPropertyAccessExpression(node.tag) &&
+          node.tag.name.text === c.functionName) ||
+          (ts.isIdentifier(node.tag) && node.tag.text === c.functionName)) &&
         ts.isNoSubstitutionTemplateLiteral(node.template)
       ) {
         const method_line = sourceFile.getLineAndCharacterOfPosition(


### PR DESCRIPTION
This PR will fix identity tag template literal sql query bug, when using bun sql or const alias of prisma.$queryRaw, just like this:
```
sql`SELECT * FROM todos WHERE id = 1;`
```
